### PR TITLE
rubocop: exclude "ruby" dir

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Excludes:
     - test/**
     - vendor/**
+    - ruby/**
 
 AlignParameters:
   Enabled: false


### PR DESCRIPTION
this helps for cases where bundle is installed to `.`:

```
bundle install --without development --path .
```

causes deps to be installed to `./ruby/...`
