### PR TITLE
OCD issues caused empty run command

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,14 +33,6 @@ default['cacti']['packages'] = value_for_platform(
     'default' => %w(cacti libsnmp-base libsnmp15 snmp snmpd libnet-ldap-perl libnet-snmp-perl php-net-ldap php5-mysql php-apc php5-snmp)
   }
 )
-default['cacti']['poller_cmd'] = value_for_platform(
-  %w(pld) => {
-    'default' => "umask 022; exec #{node['cacti']['poller_file']} >> /var/log/cacti/poller.log 2>&1"
-  },
-  %w(centos fedora redhat ubuntu) => {
-    'default' => "/usr/bin/php #{node['cacti']['poller_file']} > /dev/null 2>&1"
-  }
-)
 default['cacti']['poller_file'] = value_for_platform(
   %w(centos fedora redhat) => {
     'default' => '/usr/share/cacti/poller.php'
@@ -50,6 +42,14 @@ default['cacti']['poller_file'] = value_for_platform(
   },
   %w(ubuntu) => {
     'default' => '/usr/share/cacti/site/poller.php'
+  }
+)
+default['cacti']['poller_cmd'] = value_for_platform(
+  %w(pld) => {
+    'default' => "umask 022; exec #{node['cacti']['poller_file']} >> /var/log/cacti/poller.log 2>&1"
+  },
+  %w(centos fedora redhat ubuntu) => {
+    'default' => "/usr/bin/php #{node['cacti']['poller_file']} > /dev/null 2>&1"
   }
 )
 


### PR DESCRIPTION
reverts partially c67dbefdced4077b9cc15304beed7e0d214e3c41

`poller_cmd` uses `poller_file` attribute, so `poller_file` needs to come first

ps: http://news-hound.org/13-photos-that-will-freak-out-every-ocd-person-these-will-make-your-brain-cry/
:D
